### PR TITLE
Fix left click bug on flagged field

### DIFF
--- a/src/Minesweeper.js
+++ b/src/Minesweeper.js
@@ -81,14 +81,18 @@ export default class Minesweeper {
     unrevealField(row, column, revealedFields = []) {
         /* Amennyiben az adott mező nem érvényes (pl. negatív szám), vagy
        korábban már felfedésre került az adott hely, akkor a rekurzió befejeződik. */
+
         if (
             !this.fieldExists(row, column) ||
-            this.fields[row][column].state == State.REVEALED
+            this.fields[row][column].state == State.REVEALED ||
+            this.fields[row][column].hasMine
         ) {
             return revealedFields;
         }
 
-        if (this.fields[row][column].state == State.FLAGGED) {
+        let field = this.fields[row][column];
+
+        if (field.state == State.FLAGGED) {
             this.flaggedFields--;
         }
 


### PR DESCRIPTION
If you clicked on a flagged field which contains a mine, the recursive reveal algorithm revealed this field and neighbour empty fields. After this patch, the recursive algorithm returns before reveal if the field contains a mine.